### PR TITLE
Add monospace font (Courier) for OSX

### DIFF
--- a/src/dist/docbook-xsl/fo-pdf.xsl
+++ b/src/dist/docbook-xsl/fo-pdf.xsl
@@ -56,7 +56,7 @@
   </xsl:template>
 
   <xsl:template name="pickfont-mono">
-    <xsl:text>Liberation Mono,monospace</xsl:text>
+    <xsl:text>Liberation Mono,Courier New,Courier,monospace</xsl:text>
   </xsl:template>
 
   <xsl:template name="pickfont-dingbat">


### PR DESCRIPTION
On OSX, in order to have a monospace font embedded into generated PDF, you have to list the "Courier" font explicitly.
