### PR TITLE
resolves #25 add spacing after first paragraph in complex list item

### DIFF
--- a/src/dist/docbook-xsl/fo-pdf.xsl
+++ b/src/dist/docbook-xsl/fo-pdf.xsl
@@ -791,6 +791,24 @@
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template match="db:listitem/db:simpara[1] | listitem/simpara">
+    <xsl:choose>
+      <xsl:when test="count(following-sibling::*) > 0">
+        <!-- Treat first paragraph of complex list item as normal paragraph (padding below) -->
+        <fo:block xsl:use-attribute-sets="normal.para.spacing">
+          <xsl:call-template name="anchor"/>
+          <xsl:apply-templates/>
+        </fo:block>
+      </xsl:when>
+      <xsl:otherwise>
+        <fo:block>
+          <xsl:call-template name="anchor"/>
+          <xsl:apply-templates/>
+        </fo:block>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <!--
     Title pages
   -->


### PR DESCRIPTION
This PR adds spacing after the first paragraph of a complex list item. It does not, however, address the missing space after a nested list.
