### PR TITLE
Implement CJK support

### DIFF
--- a/asciidoctor-fopub.gemspec
+++ b/asciidoctor-fopub.gemspec
@@ -20,6 +20,18 @@ Using the asciidoctor-fopub project, you can convert any DocBook file into a nic
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.post_install_message = <<-EOF
+
+====================================================
+
+Run this command to download CJK fonts (only required for CJK documents):
+
+  $ asciidoctor-fopub-install-kai_gen_gothic-fonts
+
+====================================================
+
+  EOF
+  
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/bin/asciidoctor-fopub-install-kai_gen_gothic-fonts
+++ b/bin/asciidoctor-fopub-install-kai_gen_gothic-fonts
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'open-uri'
+require 'fileutils'
+
+FontsDir = File.expand_path(File.join(File.dirname(__FILE__),
+                                      '..', 'build', 'fopub',
+                                      'docbook-xsl', 'fonts'))
+FileUtils::mkdir_p FontsDir
+
+Fonts = %w(
+  KaiGenGothicCN-Bold-Italic.ttf
+  KaiGenGothicCN-Bold.ttf
+  KaiGenGothicCN-Regular-Italic.ttf
+  KaiGenGothicCN-Regular.ttf
+  KaiGenGothicJP-Bold-Italic.ttf
+  KaiGenGothicJP-Bold.ttf
+  KaiGenGothicJP-Regular-Italic.ttf
+  KaiGenGothicJP-Regular.ttf
+  KaiGenGothicKR-Bold-Italic.ttf
+  KaiGenGothicKR-Bold.ttf
+  KaiGenGothicKR-Regular-Italic.ttf
+  KaiGenGothicKR-Regular.ttf
+  KaiGenGothicTW-Bold-Italic.ttf
+  KaiGenGothicTW-Bold.ttf
+  KaiGenGothicTW-Regular-Italic.ttf
+  KaiGenGothicTW-Regular.ttf
+  RobotoMono-Bold.ttf
+  RobotoMono-BoldItalic.ttf
+  RobotoMono-Italic.ttf
+  RobotoMono-Regular.ttf
+)
+
+Dir.chdir(FontsDir) do
+  Fonts.each_with_index do |name, index|
+    puts "[#{index + 1}/#{Fonts.count}] Downloading #{name}"
+    File.open(name, 'wb') do |file|
+      file.write open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
+    end
+  end
+end
+
+puts "Done"

--- a/fopub
+++ b/fopub
@@ -110,6 +110,30 @@ if [ "$SOURCE_EXTENSION" == "xml" ]; then
   fi
 fi
 
+function find_lang() {
+  grep "xml:lang" "$1" | sed -e 's|.*xml:lang="\(.*\)".*|\1|g' | head -n 1
+}
+# Find out the language and force fop to use it.
+#
+# NOTE: we force the document language via the 'l10n.gentext.language'
+# attribute by setting it through the fop commandline. This makes the language
+# directly visiable to the docbook xsl, so we can use it to customize
+# attributes for different languages. For example, we can customize CJK fonts
+# based on the document language. This seem the only viable approach since the
+# `pick-sans` templates seems to get evaluated before parsing the documents
+# (so we can not obtain the correct document language in the template).
+DOCUMENT_LANG=`find_lang "$SOURCE_FILE"`
+if [ -z "$DOCUMENT_LANG" ]; then
+  DOCUMENT_LANG="en"
+fi
+
+# Modify fop-config.xml to fix bundled font-path
+FOP_CONFIG_XML="$DOCBOOK_XSL_ABS_DIR/fop-config.xml"
+BUNDLED_FONTS_DIR="$DOCBOOK_XSL_ABS_DIR/fonts"
+if [ -f "$FOP_CONFIG_XML" ]; then
+  sed -i "s|@FONT-BASE@|$BUNDLED_FONTS_DIR|g" "$FOP_CONFIG_XML"
+fi
+
 case $FORMAT in
   pdf|ps)
     CONVERT_ARGS="$CONVERT_ARGS -$FORMAT \"$OUT_FILE\""
@@ -128,6 +152,7 @@ esac
 eval $FOPUB_CMD -q -catalog \
   -c \"$DOCBOOK_XSL_DIR/fop-config.xml\" \
   $CONVERT_ARGS \
+  -param l10n.gentext.language \"$DOCUMENT_LANG\" \
   -param highlight.xslthl.config \"$XSLTHL_CONFIG_URI\" \
   -param admon.graphics.path \"$DOCBOOK_DIR/images/\" \
   -param callout.graphics.path \"$DOCBOOK_DIR/images/callouts/\" "$@"

--- a/src/dist/docbook-xsl/fo-pdf.xsl
+++ b/src/dist/docbook-xsl/fo-pdf.xsl
@@ -21,6 +21,7 @@
   <xsl:import href="common.xsl"/>
   <xsl:import href="highlight.xsl"/>
   <xsl:import href="callouts.xsl"/>
+  <xsl:import href="fonts.xsl"/>
 
   <!-- Enable extensions for FOP version 0.90 and later -->
   <xsl:param name="fop1.extensions">1</xsl:param>
@@ -44,35 +45,9 @@
   </xsl:template>
 
   <!--
-    Font selectors
-  -->
-
-  <xsl:template name="pickfont-sans">
-    <xsl:text>Arial,sans-serif</xsl:text>
-  </xsl:template>
-
-  <xsl:template name="pickfont-serif">
-    <xsl:text>Georgia,serif</xsl:text>
-  </xsl:template>
-
-  <xsl:template name="pickfont-mono">
-    <xsl:text>Liberation Mono,Courier New,Courier,monospace</xsl:text>
-  </xsl:template>
-
-  <xsl:template name="pickfont-dingbat">
-    <xsl:call-template name="pickfont-sans"/>
-  </xsl:template>
-
-  <xsl:template name="pickfont-symbol">
-    <xsl:text>Symbol,ZapfDingbats</xsl:text>
-  </xsl:template>
-
-  <xsl:template name="pickfont-math">
-    <xsl:text>Liberation Serif,Times-Roman</xsl:text>
-  </xsl:template>
-
-  <!--
     Fonts
+
+    Selectors are defined in fonts.xsl
   -->
 
   <xsl:param name="body.font.family">

--- a/src/dist/docbook-xsl/fonts.xsl
+++ b/src/dist/docbook-xsl/fonts.xsl
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:fo="http://www.w3.org/1999/XSL/Format">
+
+  <!--
+    Font selectors
+  -->
+
+  <xsl:variable name="lang">
+    <xsl:call-template name="l10n.language"/>
+  </xsl:variable>
+
+  <xsl:template name="pickfont-sans">
+    <xsl:choose>
+      <xsl:when test="$lang = 'zh_cn'">
+        <xsl:text>KaiGenGothicCN, sans-serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'zh_tw'">
+        <xsl:text>KaiGenGothicTW, sans-serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ja'">
+        <xsl:text>KaiGenGothicJP, sans-serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ko'">
+        <xsl:text>KaiGenGothicKR, sans-serif</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>Arial, sans-serif</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="pickfont-serif">
+    <xsl:choose>
+      <xsl:when test="$lang = 'zh_cn'">
+        <xsl:text>KaiGenGothicCN, serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'zh_tw'">
+        <xsl:text>KaiGenGothicTW, serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ja'">
+        <xsl:text>KaiGenGothicJP, serif</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ko'">
+        <xsl:text>KaiGenGothicKR, serif</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>Georgia, sans-serif</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="pickfont-mono">
+    <xsl:choose>
+      <xsl:when test="$lang = 'zh_cn'">
+        <xsl:text>RobotoMono, KaiGenGothicCN, monospace</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'zh_tw'">
+        <xsl:text>RobotoMono, KaiGenGothicTW, monospace</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ja'">
+        <xsl:text>RobotoMono, KaiGenGothicJP, monospace</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'ko'">
+        <xsl:text>RobotoMono, KaiGenGothicKR, monospace</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>Liberation Mono, Courier New, Courier, monospace</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="pickfont-dingbat">
+    <xsl:call-template name="pickfont-sans"/>
+  </xsl:template>
+
+  <xsl:template name="pickfont-symbol">
+    <xsl:text>Symbol,ZapfDingbats</xsl:text>
+  </xsl:template>
+
+  <xsl:template name="pickfont-math">
+    <xsl:text>Liberation Serif,Times-Roman</xsl:text>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/dist/docbook-xsl/fop-config.xml
+++ b/src/dist/docbook-xsl/fop-config.xml
@@ -1,10 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fop version="1.0">
+  <font-base>@FONT-BASE@</font-base>
   <strict-configuration>true</strict-configuration>
   <renderers>
     <renderer mime="application/pdf">
       <fonts>
-        <auto-detect />
+        <font kerning="yes" embed-url="RobotoMono-Regular.ttf">
+          <font-triplet name="RobotoMono" style="normal" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="RobotoMono-Bold.ttf">
+          <font-triplet name="RobotoMono" style="normal" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="RobotoMono-BoldItalic.ttf">
+          <font-triplet name="RobotoMono" style="italic" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicCN-Regular.ttf">
+          <font-triplet name="KaiGenGothicCN" style="normal" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicCN-Bold.ttf">
+          <font-triplet name="KaiGenGothicCN" style="normal" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicCN-Regular-Italic.ttf">
+          <font-triplet name="KaiGenGothicCN" style="italic" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicCN-Bold-Italic.ttf">
+          <font-triplet name="KaiGenGothicCN" style="italic" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicTW-Regular.ttf">
+          <font-triplet name="KaiGenGothicTW" style="normal" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicTW-Bold.ttf">
+          <font-triplet name="KaiGenGothicTW" style="normal" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicTW-Regular-Italic.ttf">
+          <font-triplet name="KaiGenGothicTW" style="italic" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicTW-Bold-Italic.ttf">
+          <font-triplet name="KaiGenGothicTW" style="italic" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicJP-Regular.ttf">
+          <font-triplet name="KaiGenGothicJP" style="normal" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicJP-Bold.ttf">
+          <font-triplet name="KaiGenGothicJP" style="normal" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicJP-Regular-Italic.ttf">
+          <font-triplet name="KaiGenGothicJP" style="italic" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicJP-Bold-Italic.ttf">
+          <font-triplet name="KaiGenGothicJP" style="italic" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicKR-Regular.ttf">
+          <font-triplet name="KaiGenGothicKR" style="normal" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicKR-Bold.ttf">
+          <font-triplet name="KaiGenGothicKR" style="normal" weight="bold"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicKR-Regular-Italic.ttf">
+          <font-triplet name="KaiGenGothicKR" style="italic" weight="normal"/>
+        </font>
+        <font kerning="yes" embed-url="KaiGenGothicKR-Bold-Italic.ttf">
+          <font-triplet name="KaiGenGothicKR" style="italic" weight="bold"/>
+        </font>
+        <auto-detect/>
       </fonts>
     </renderer>
   </renderers>


### PR DESCRIPTION
Due to lack of fonts, current asciidoctor-fopub does not support CJK documents. CJK characters will be rendered as "#" in output pdfs. This is annoy for CJK users.

This pull request fixes the above problem using open source fonts and automatic language detection. To be specific, it implements the following functionalities:
1. **Download and install KaiGenGothic fonts when users request**. KaiGenGothic fonts is the ttf version of Adobe Source Han Sans fonts created by akiratw? and released open-sourced. Since they are open sourced by legel owners, there are no copyright problems. Here I use the enhanced version (+bold, +italic, +bold_italic) created by chloerei at https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic.
2. **Add static font definitions into the original `fop-config.xml`**. This makes sure the installed fonts is selected and selected by correct names.
3. **Add language detection in `fopub` to automatically detect and set language code to fop**. The detection just scans the input xml for "xml:lang" attributes and default to "en".
4. **Add automatic font switching in `fo-pdf.xsl`**. KaiGenGothic is used for CJK documents and the original fonts are used for other languages. This is done **automatically**.

I have tested it with `README.adoc` by setting lang attributes to `zh_CN`, `zh_TW`, `ja` and `ko`. The chapter titles and figure captions works fine. I use it for full Chinese documents for a while and it just works.

Caveat: The 'fopub' script check and modify fop-config.xml for font path on every invocation. It would be nice if there are other ways to do it. I have tried to use post-install hook but failed. One can still use gradle job to change the font path on first fopub invocation, but I am not quite into gradle. Help is welcome.
