### PR TITLE
workaround for bogus errors using sed in OS X

### DIFF
--- a/fopub
+++ b/fopub
@@ -106,7 +106,7 @@ if [ "$SOURCE_EXTENSION" == "xml" ]; then
   CONVERT_ARGS="$CONVERT_ARGS -xsl \"$DOCBOOK_XSL_DIR/fo-pdf.xsl\""
   if [ `grep -c '^<!DOCTYPE \(book\|article\)' "$SOURCE_FILE"` == 0 ]; then
     # QUESTION should we work on a copy?
-    sed -i "s:<\(book\|article\):<!DOCTYPE \1 [<!ENTITY % db5ent PUBLIC \"-//FOPUB//ENTITIES Entities for DocBook 5\" \"db5.ent\"> %db5ent;]>\n<\1:" "$SOURCE_FILE"
+    sed -i '' "s:<\(book\|article\):<!DOCTYPE \1 [<!ENTITY % db5ent PUBLIC \"-//FOPUB//ENTITIES Entities for DocBook 5\" \"db5.ent\"> %db5ent;]>\n<\1:" "$SOURCE_FILE"
   fi
 fi
 


### PR DESCRIPTION
When running fopub on OSX, the following errors occur:

```sed: 1: "generated-docs/mmltypes ...": extra characters at the end of g command```

See: http://stackoverflow.com/questions/16745988/sed-command-works-fine-on-ubuntu-but-not-mac

This minor edit is a temporary workaround to avoid redundant errors in the console.