### PR TITLE
Windows fopub.bat support for -t|-f|-H options, ps output and passing additional parameters to fop

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -185,8 +185,6 @@ You'll now notice that the PDF generated is rendered in landscape mode.
 
 NOTE: See http://docbook.sourceforge.net/release/xsl/1.78.1/doc/param.html[DocBook XSL parameter reference] for a list of all XSL parameters you can set.
 
-CAUTION: Custom parameters are currently only implemented in the Unix version of the fopub script.
-
 === Custom XSL templates
 
 When you work on many documentations projets in *parallel*, you will probably need different outputs.

--- a/fopub.bat
+++ b/fopub.bat
@@ -87,18 +87,26 @@ set DOCBOOK_DIR_PARAM=!DOCBOOK_DIR_PARAM:\=/!
 set XSLTHL_CONFIG_URI=!XSLTHL_CONFIG_URI:\=/!
 
 if "%TYPE%" == "pdf" (
-  set OUTPUT_PDF_FILE="%SOURCE_ROOTNAME%.pdf"
-  %FOPUB_CMD% -q -catalog -c "%DOCBOOK_XSL_DIR%\fop-config.xml" -xml "%SOURCE_FILE%" -xsl "%DOCBOOK_XSL_DIR%\fo-pdf.xsl" -pdf !OUTPUT_PDF_FILE! -param highlight.xslthl.config "%XSLTHL_CONFIG_URI%" -param admon.graphics.path "%DOCBOOK_DIR_PARAM%/images/" -param callout.graphics.path "%DOCBOOK_DIR_PARAM%/images/callouts/" %CONVERT_ARGS%
-  if not "%ERRORLEVEL%"=="0" goto fail else goto mainEnd
+  set OUTPUT_FILE=%SOURCE_ROOTNAME%.pdf
+  set OUTPUT_OPT=-pdf
+)
+
+if "%TYPE%" == "ps" (
+  set OUTPUT_FILE=%SOURCE_ROOTNAME%.ps
+  set OUTPUT_OPT=-ps
 )
 
 if "%TYPE%" == "fo" (
-  set OUTPUT_FO_FILE="%SOURCE_ROOTNAME%.fo"
-  %FOPUB_CMD% -q -catalog -c "%DOCBOOK_XSL_DIR%\fop-config.xml" -xml "%SOURCE_FILE%" -xsl "%DOCBOOK_XSL_DIR%\fo-pdf.xsl" -foout !OUTPUT_FO_FILE! -param highlight.xslthl.config "%XSLTHL_CONFIG_URI%" -param admon.graphics.path "%DOCBOOK_DIR_PARAM%/images/" -param callout.graphics.path "%DOCBOOK_DIR_PARAM%/images/callouts/" %CONVERT_ARGS%
-  if not "%ERRORLEVEL%"=="0" goto fail else goto mainEnd
+  set OUTPUT_FILE=%SOURCE_ROOTNAME%.fo
+  set OUTPUT_OPT=-foout
 )
 
-echo "Unsupported output type %TYPE%"
+if NOT "%OUTPUT_FILE%" == "" (
+   %FOPUB_CMD% -q -catalog -c "%DOCBOOK_XSL_DIR%\fop-config.xml" -xml "%SOURCE_FILE%" -xsl "%DOCBOOK_XSL_DIR%\fo-pdf.xsl" !OUTPUT_OPT! !OUTPUT_FILE! -param highlight.xslthl.config "%XSLTHL_CONFIG_URI%" -param admon.graphics.path "%DOCBOOK_DIR_PARAM%/images/" -param callout.graphics.path "%DOCBOOK_DIR_PARAM%/images/callouts/" %CONVERT_ARGS%
+   if not "%ERRORLEVEL%"=="0" goto fail else goto mainEnd
+)
+
+echo "Unsupported output type '%TYPE%'. Must be pdf, ps or fo."
 
 :fail
 exit /b 1

--- a/fopub.bat
+++ b/fopub.bat
@@ -18,7 +18,7 @@ set FOPUB_DIR=%PRG_DIR%\build\fopub
 set FOPUB_CMD=%FOPUB_DIR%\bin\fopub.bat
 
 set DOCBOOK_DIR=%FOPUB_DIR%\docbook
-set DOCBOOK_XSL_DIR=%FOPUB_DIR%\docbook-xsl
+if not defined DOCBOOK_XSL_DIR set DOCBOOK_XSL_DIR=%FOPUB_DIR%\docbook-xsl
 set XSLTHL_CONFIG_URI=file:///%DOCBOOK_XSL_DIR%\xslthl-config.xml
 
 :init


### PR DESCRIPTION
The patch makes fopub.bat on Windows close to having the same functionality as the fopub shell script on Unix. The command line syntax is also the same

`fopub [-t XSLDIRPATH] [-f pdf|ps|fo] [-H] INPUTFILE [-param ....]`

Readme as been updated accordingly.

An unrelated comment - when running for the first time on Windows, fopub must be run from within the asciidoctor-fopub directory else it fails to find gradle. This bug is also present in the original fopub.bat so should not be a cause to reject this patch.