### PR TITLE
Change the stylesheet-importing URL to an SSL one

### DIFF
--- a/src/dist/docbook-xsl/fo-pdf.xsl
+++ b/src/dist/docbook-xsl/fo-pdf.xsl
@@ -12,12 +12,12 @@
     The absolute URL imports point to system-wide locations by way of this /etc/xml/catalog entry:
   
       <rewriteURI
-        uriStartString="http://docbook.sourceforge.net/release/xsl/current"
+        uriStartString="https://cdn.docbook.org/release/xsl/current"
         rewritePrefix="file:///usr/share/sgml/docbook/xsl-stylesheets-%docbook-style-xsl-version%"/>
   
     %docbook-style-xsl-version% represents the version installed on the system.
   -->
-  <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
+  <xsl:import href="https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl"/>
   <xsl:import href="common.xsl"/>
   <xsl:import href="highlight.xsl"/>
   <xsl:import href="callouts.xsl"/>


### PR DESCRIPTION
When I open the file in oXygen Editor, it bitches and moans that the URL is not a trusted location :-/
--and I can't get it to quit. Anyway, maybe it's time to go HTTPS here, too...