### PR TITLE
Fix missing double quotes around `fopub` command

### DIFF
--- a/fopub
+++ b/fopub
@@ -137,7 +137,7 @@ case $FORMAT in
   ;;
 esac
 
-eval $FOPUB_CMD -q -catalog \
+eval \"$FOPUB_CMD\" -q -catalog \
   -c \"$DOCBOOK_XSL_DIR/fop-config.xml\" \
   $CONVERT_ARGS \
   -param highlight.xslthl.config \"$XSLTHL_CONFIG_URI\" \


### PR DESCRIPTION
Missing double quotes triggers an error when `fopub` script is called with a path containing spaces.

For instance :
```
$ fopub document.xml
... # OK
$ foo\ directory\ with\ spaces/fopub document.xml
foo directory with spaces/fopub: line 140: foo: command not found
```

This PR fixes the problem.