### PR TITLE
update gradle version to 4.10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi! Thanks for everything about the development of AsciiDoctor

I recently wanted to try the `AsciiDoc -> DocBook -> PDF` toolchain to see the differences with _asciidoctor-pdf_. I had the same problem reported in issue #102 and I think it's good to make this change, even if this project is unmaintained.

I´d stop at Gradle 4.10 because a newer version could do more damage than benefit, but I didn't try to use a newer one. With 4.10 I could complete the tutorial conversion and a custom conversion. 

close #102  